### PR TITLE
Update styles-reloader.js

### DIFF
--- a/lib/styles-reloader.js
+++ b/lib/styles-reloader.js
@@ -24,7 +24,7 @@ module.exports = function StylesReloader(options){
   // livereload hostname
   var liveReloadHostname = [
     (options.ssl ? 'https://' :'http://'),
-    (options.liveReloadHost || options.host || "localhost"),
+    (options.liveReloadHost || options.host || 'localhost'),
     ':',
     options.liveReloadPort
   ].join('');

--- a/lib/styles-reloader.js
+++ b/lib/styles-reloader.js
@@ -24,7 +24,7 @@ module.exports = function StylesReloader(options){
   // livereload hostname
   var liveReloadHostname = [
     (options.ssl ? 'https://' :'http://'),
-    (options.liveReloadHost || options.host),
+    (options.liveReloadHost || options.host || "localhost"),
     ':',
     options.liveReloadPort
   ].join('');


### PR DESCRIPTION
Adds a `localhost` fallback for the `liveReloadHost` in case it returns undefined.
