### PR TITLE
Check for vendor styles instead app styles, which is more fragile

### DIFF
--- a/lib/styles-reloader.js
+++ b/lib/styles-reloader.js
@@ -17,8 +17,8 @@ module.exports = function StylesReloader(options){
   var lsProxy = options.ssl ? require('https') : require('http');
 
   // build app style pattern
-  var appStylePath = path.join(options.project.root, 'app', 'styles', '*');
-  var appStylePattern = new RegExp('^' + appStylePath);
+  var vendorStylePath = path.join(options.project.root, 'vendor', '*');
+  var vendorStylePattern = new RegExp('^' + vendorStylePath);
   var appStyleResource = options.project.pkg.name + '.css';
 
   // livereload hostname
@@ -35,7 +35,7 @@ module.exports = function StylesReloader(options){
   };
 
   function getReloadResource(filePath){
-    return filePath.match(appStylePattern) ? appStyleResource : 'vendor.css';
+    return filePath.match(vendorStylePattern) ? "vendor.css" : appStyleResource;
   };
 
   function fileDidChange(results){
@@ -44,7 +44,7 @@ module.exports = function StylesReloader(options){
     // notify livereload server if needed
     if (shouldReload(filePath)){
       var reloadResource = getReloadResource(filePath);
-      ui.writeLine('Reloading ' + reloadResource + ' only');
+      ui.writeLine('Reloading ' + reloadResource + ' only from: ' + filePath);
       lsProxy.get(liveReloadHostname + '/changed?files=' + reloadResource)
           .on('error', noop);
     }


### PR DESCRIPTION
I have styles in in-repo addons that are compiled into the `app.css`-file, but `ember-cli-styles-reloader` was assuming it was vendor. The whole check seemed a bit brittle, so I refactored it to explicitly only check for vendor. What do you think @xomaczar? 
